### PR TITLE
docker: podman-friendly image locations

### DIFF
--- a/cms_reco/cookiecutter_templates/workflow_factory/cwl/{{cookiecutter.directory_name}}/workflow/reco.cwl
+++ b/cms_reco/cookiecutter_templates/workflow_factory/cwl/{{cookiecutter.directory_name}}/workflow/reco.cwl
@@ -3,7 +3,7 @@ cwlVersion: v1.0
 
 requirements:
   - class: DockerRequirement
-    dockerPull: cmsopendata/cmssw_{{cookiecutter.cmssw_version}}
+    dockerPull: docker.io/cmsopendata/cmssw_{{cookiecutter.cmssw_version}}
 
 baseCommand:
   - /bin/zsh

--- a/cms_reco/cookiecutter_templates/workflow_factory/serial/{{cookiecutter.directory_name}}/{{cookiecutter.yaml_file_name}}.yaml
+++ b/cms_reco/cookiecutter_templates/workflow_factory/serial/{{cookiecutter.directory_name}}/{{cookiecutter.yaml_file_name}}.yaml
@@ -10,7 +10,7 @@ workflow:
   type: serial
   specification:
     steps:
-      - environment: 'cmsopendata/cmssw_{{cookiecutter.cmssw_version}}'
+      - environment: 'docker.io/cmsopendata/cmssw_{{cookiecutter.cmssw_version}}'
         compute_backend: {{cookiecutter.compute_backend}}
         commands:
         - >

--- a/reana.yaml
+++ b/reana.yaml
@@ -6,7 +6,7 @@ workflow:
   type: serial
   specification:
     steps:
-      - environment: 'cmsopendata/cmssw_5_3_32'
+      - environment: 'docker.io/cmsopendata/cmssw_5_3_32'
         commands:
         - source /opt/cms/cmsset_default.sh && scramv1 project CMSSW CMSSW_5_3_32 && cd CMSSW_5_3_32/src && eval `scramv1 runtime -sh` && scp ../../reco_cmsdriver2011.py . && ln -sf /cvmfs/cms-opendata-conddb.cern.ch/FT_53_LV5_AN1_RUNA FT_53_LV5_AN1 && ln -sf /cvmfs/cms-opendata-conddb.cern.ch/FT_53_LV5_AN1_RUNA.db FT_53_LV5_AN1_RUNA.db && ls -l && ls -l /cvmfs/ && cmsRun reco_cmsdriver2011.py
 

--- a/workflow/step1.cwl
+++ b/workflow/step1.cwl
@@ -3,7 +3,7 @@ cwlVersion: v1.0
 
 requirements:
   - class: DockerRequirement
-    dockerPull: cmsopendata/cmssw_5_3_32
+    dockerPull: docker.io/cmsopendata/cmssw_5_3_32
 
 baseCommand:
   - /bin/zsh


### PR DESCRIPTION
Adds fully qualified canonical locations of container images, making the container technology setup podman-friendly.

Closes reanahub/reana#729.