### PR TITLE
tests: allow execution of selected pytests only

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,8 @@
 # This file is part of REANA.
-# Copyright (C) 2019 CERN.
+# Copyright (C) 2019, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 [pytest]
-addopts = --pep8 --ignore=docs --cov=cms_reco --cov-report=term-missing
+addopts = --ignore=docs --cov=cms_reco --cov-report=term-missing --cov-report=xml

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,12 +1,46 @@
-#!/bin/sh
+#!/bin/bash
 #
 # This file is part of REANA.
-# Copyright (C) 2019 CERN.
+# Copyright (C) 2019, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-#ToDo: use the branches for different years as tests cases
+# Quit on errors
+set -o errexit
 
-pydocstyle cms_reco && \
-python setup.py test
+# Quit on unbound symbols
+set -o nounset
+
+check_script () {
+    shellcheck run-tests.sh
+}
+
+check_pydocstyle () {
+    pydocstyle cms_reco
+}
+
+check_pytest () {
+    python setup.py test
+}
+
+check_all () {
+    check_script
+    check_pydocstyle
+    check_pytest
+}
+
+if [ $# -eq 0 ]; then
+    check_all
+    exit 0
+fi
+
+for arg in "$@"
+do
+    case $arg in
+        --check-shellscript) check_script;;
+        --check-pydocstyle) check_pydocstyle;;
+        --check-pytest) check_pytest;;
+        *)
+    esac
+done

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of reana
-# Copyright (C) 2019, 2022 CERN.
+# Copyright (C) 2019, 2022, 2023 CERN.
 #
 # reana is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -16,7 +16,7 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 tests_require = [
-    'pytest-reana>=0.6.0.dev20190705,<0.7.0',
+    "pytest-reana>=0.9.1,<0.10.0",
 ]
 
 extras_require = {
@@ -34,7 +34,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    'click>=7,<8',
+    'click>=7',
     'cookiecutter>=1.6.0',
     'jq>=0.1.6'
 ]

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of reana.
-# Copyright (C) 2019 CERN.
+# Copyright (C) 2019, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 
-from tests.utils_test import workflow_test
+from utils_test import workflow_test
 
 
 def test_2010_jet_serial():


### PR DESCRIPTION
Updates the test infrastructure to use latest `pytest-reana` package.

Enriches the test infrastructure to check for shell script style.

Allows execution of selected pytests via PYTESTARG environment variable. Example: `PYTESTARG="-k test_version" ./run-tests.sh --check-pytest`.

Closes reanahub/reana#755.