### PR TITLE
refactor(pytest): drop pytest-reana and use pytest directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ readme = open("README.md").read()
 history = open("CHANGELOG.md").read()
 
 tests_require = [
-    "pytest-reana>=0.9.1,<0.10.0",
+    "pytest>=7.0.0,<9.0.0",
 ]
 
 extras_require = {


### PR DESCRIPTION
Replace pytest-reana in tests_require with pytest directly. The demo's tests do not import any fixture from pytest-reana; the dependency only pulled pytest transitively.